### PR TITLE
Add step="any" prop to input

### DIFF
--- a/src/components/__snapshots__/currency-input.test.js.snap
+++ b/src/components/__snapshots__/currency-input.test.js.snap
@@ -4,6 +4,7 @@ exports[`when rendered with required props renders the input 1`] = `
 <input
   onChange={[Function]}
   pattern="\\\\d*"
+  step="any"
   type="number"
   value=""
 />

--- a/src/components/currency-input.js
+++ b/src/components/currency-input.js
@@ -45,6 +45,7 @@ export default class CurrencyInput extends Component {
       <input
         type="number"
         pattern="\d*"
+        step="any"
         {...inputProps}
         value={value}
         onChange={handleChange}


### PR DESCRIPTION
Closes #46, relevant details in that issue.

I verified locally by just copy/pasting the source files into another project and setting up a dummy page

### Firefox bad

<img width="371" alt="firefox-bad-1" src="https://user-images.githubusercontent.com/8379268/73477219-b022d300-4348-11ea-87c3-bfee8d01bfdf.png">
<img width="366" alt="firefox-bad-2" src="https://user-images.githubusercontent.com/8379268/73477220-b0bb6980-4348-11ea-9ee8-d84ed3d1c77c.png">

### Firefox good

<img width="326" alt="firefox-good-1" src="https://user-images.githubusercontent.com/8379268/73477233-b7e27780-4348-11ea-84d0-3ab2425f4c55.png">
<img width="337" alt="firefox-good-2" src="https://user-images.githubusercontent.com/8379268/73477234-b7e27780-4348-11ea-9f9a-7c62b36bd259.png">

### Chrome (verifying it didn't break)

<img width="280" alt="chrome1" src="https://user-images.githubusercontent.com/8379268/73477256-c03ab280-4348-11ea-8929-ff6cedb6a5da.png">
<img width="276" alt="chrome2" src="https://user-images.githubusercontent.com/8379268/73477257-c03ab280-4348-11ea-9a51-05f90a5eb00f.png">

### Safari (verifying it didn't break)

<img width="272" alt="safari1" src="https://user-images.githubusercontent.com/8379268/73477275-c6309380-4348-11ea-80aa-730b20b4218d.png">
<img width="276" alt="safari2" src="https://user-images.githubusercontent.com/8379268/73477276-c6c92a00-4348-11ea-8441-45eff4e08f62.png">

### Edge (via parallels) (verifying it didn't break)

<img width="341" alt="edge11" src="https://user-images.githubusercontent.com/8379268/73477594-67b7e500-4349-11ea-86c0-c2e9491d0217.png">
<img width="308" alt="edge22" src="https://user-images.githubusercontent.com/8379268/73477595-67b7e500-4349-11ea-9fa1-57c9ef66b6ef.png">

